### PR TITLE
DO-926 Rewrite mysql root ini file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 source 'http://gems.optoro.io/'
 
 gem 'berkshelf', '~> 4.0.1'
+gem 'chef-rewind'
 
 group :integration do
   gem 'test-kitchen', '~> 1.4.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'This is a wrapper around the percona cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.26'
+version '0.0.27'
 
 supports 'ubuntu', '= 14.04'
 

--- a/recipes/create_inifile.rb
+++ b/recipes/create_inifile.rb
@@ -1,0 +1,13 @@
+chef_gem 'chef-rewind'
+require 'chef/rewind'
+
+mysql_creds = Chef::EncryptedDataBagItem.load(node['percona']['encrypted_data_bag'], 'mysql')
+
+rewind template: '/root/.my.cnf' do
+  action :create
+  owner 'root'
+  group 'root'
+  source 'my.cnf.root.erb'
+  cookbook_name 'optoro_mysql'
+  variables(root_password: mysql_creds['root'])
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,7 @@ include_recipe 'optoro_mysql::create_mysql_directories'
 include_recipe 'optoro_mysql::setup'
 include_recipe 'optoro_mysql::add_percona_repo' if node['optoro_mysql']['use_custom_repo']
 include_recipe 'percona::server'
+include_recipe 'optoro_mysql::create_inifile'
 include_recipe 'optoro_mysql::log_fix'
 include_recipe 'percona::toolkit'
 include_recipe 'percona::backup'

--- a/templates/default/my.cnf.root.erb
+++ b/templates/default/my.cnf.root.erb
@@ -1,0 +1,5 @@
+<% %w[client mysqladmin mysqldump].each do |record| -%>
+[<%= record %>]
+user=root
+password=<%= @root_password %>
+<% end -%>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -30,4 +30,8 @@ describe 'MySQL Service' do
   describe file('/etc/mysql/my.cnf') do
     it { should contain('innodb_use_native_aio = 1') }
   end
+
+  describe file('/root/.my.cnf') do
+    it { should contain('password=testing123') }
+  end
 end


### PR DESCRIPTION
The ini file template surrounds the password in single quotes. This is
not an issue for the mysql client, but it does interfere with parsing
it via the inifile gem. The inifile gem keeps the single quotes and
cannot authenticate.