### PR TITLE
/var/optoro/mysql_backups needs to be owned by deploy since backups a…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'This is a wrapper around the percona cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.38'
+version '0.0.39'
 
 supports 'ubuntu', '= 14.04'
 

--- a/recipes/backup.rb
+++ b/recipes/backup.rb
@@ -40,8 +40,8 @@ else
   end
 
   directory node['optoro_mysql']['backup_directory'] do
-    owner 'root'
-    group 'root'
+    owner 'deploy'
+    group 'deploy'
     mode '0755'
   end
 end


### PR DESCRIPTION
…re run as deploy.  Otherwise the backup job will fail for permission errors