### PR TITLE
fix mysql.json.  was dumping entire nested service entry into tags wh…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'This is a wrapper around the percona cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/optoro-devops/optoro_mysql'
-version '0.0.44'
+version '0.0.45'
 
 supports 'ubuntu', '= 14.04'
 

--- a/recipes/consul.rb
+++ b/recipes/consul.rb
@@ -1,10 +1,14 @@
 include_recipe 'optoro_consul::client'
 
+# always want fqdn as a tag...if there are additional service tags specified
+# then add them to the tags array as well, have to check that keys exist to avoid explosion
+tags = (node['optoro_consul'].key?('service') ? node['optoro_consul']['service'].fetch('tags', []) : []) | [node['fqdn']]
+
 consul_definition 'mysql' do
   type 'service'
   parameters(
     port: 3306,
-    tags: [node['fqdn'], node['optoro_consul']['service']],
+    tags: tags,
     enableTagOverride: false,
     check: {
       interval: '10s',


### PR DESCRIPTION
…ich created a bogus config.  check if service tags exist and add them to fqdn instead


tags: [node['fqdn'], node['optoro_consul']['service']]   is dumping the entire service into the tags section instead of just appending any additional tags which creates bogus config file like:
```
{
  "service": {
    "port": 3306,
    "tags": [
      "percona-005.optiturn.com",
      {
        "tags": [
          "mysql",
          "primary"
        ],
        "checks": [
          {
            "script": "netstat -tunlp | grep \"LISTEN\" | grep 3306",
            "interval": "5s"
          }
        ]
      }
    ],
    "enableTagOverride": false,
    "check": {
      "interval": "10s",
      "timeout": "5s",
      "http": "http://localhost:3306/metrics"
    },
    "name": "mysql"
  }
}
```
